### PR TITLE
Corrected indexesOfCommonElementsWithArray for row insertion.

### DIFF
--- a/LongestCommonSubsequence/NSArray+LongestCommonSubsequence.m
+++ b/LongestCommonSubsequence/NSArray+LongestCommonSubsequence.m
@@ -65,11 +65,7 @@
                 i++;
                 j++;
             } else {
-                NSInteger currentIndex = i;
-                while ([_addedIndexes containsIndex:currentIndex]) {
-                    currentIndex++;
-                }
-                [_addedIndexes addIndex:currentIndex];
+                [_addedIndexes addIndex:j];
                 j++;
             }
         }

--- a/LongestCommonSubsequenceTests/LongCommonSubsequenceInTableView.m
+++ b/LongestCommonSubsequenceTests/LongCommonSubsequenceInTableView.m
@@ -24,10 +24,11 @@
     [super setUp];
     
 
-    self.tableView = [[UITableView alloc] init];
+    self.tableView = [[UITableView alloc] initWithFrame:UIApplication.sharedApplication.keyWindow.bounds];
     _tableView.delegate = self;
     _tableView.dataSource = self;
     
+    [UIApplication.sharedApplication.keyWindow addSubview:_tableView];
     [self resetTableView];
 }
 
@@ -40,6 +41,7 @@
 - (void) resetTableView {
     self.sourceData = @[@"a", @"b", @"c", @"d", @"e"];
     [_tableView reloadData];
+    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1f]];
 }
 
 - (void)testRemovingOneItem
@@ -94,6 +96,21 @@
     
 }
 
+- (void)testAddingTwoNonAdjacentItems
+{
+    [self resetTableView];
+    
+    [self switchToNewDataSource:@[@"a", @"a.1", @"b", @"c", @"c.2", @"d", @"e", @"e.3"]];
+}
+
+- (void)testReordering
+{
+    [self resetTableView];
+    
+    [self switchToNewDataSource:@[@"b", @"e", @"d", @"c", @"a"]];
+}
+
+
 - (void)testSwitchingOneItem
 {
     [self resetTableView];
@@ -121,11 +138,23 @@
     }];
     
     [_tableView beginUpdates];
-    [_tableView insertRowsAtIndexPaths:indexPathsToAdd withRowAnimation:UITableViewRowAnimationAutomatic];
-    [_tableView deleteRowsAtIndexPaths:indexPathsToDelete withRowAnimation:UITableViewRowAnimationAutomatic];
+    [_tableView insertRowsAtIndexPaths:indexPathsToAdd withRowAnimation:UITableViewRowAnimationNone];
+    [_tableView deleteRowsAtIndexPaths:indexPathsToDelete withRowAnimation:UITableViewRowAnimationNone];
     [_tableView endUpdates];
+    
+    [self verifyCells];
 }
 
+- (void) verifyCells
+{
+    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1f]];
+    
+    XCTAssert([_tableView numberOfRowsInSection:0] == self.sourceData.count, @"number of rows in table view should equal source data count");
+    for (NSUInteger i = 0; i < self.sourceData.count; i++) {
+        NSString* cellLabel = [_tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:i inSection:0]].textLabel.text;
+        XCTAssert([cellLabel isEqualToString:self.sourceData[i]], @"result cells should equal expected");
+    }
+}
 
 #pragma mark - UITableViewDataSource
 


### PR DESCRIPTION
Hi! Thanks a lot for your work on this. I was looking for something like this to use. I found that indexesOfCommonElementsWithArray:addedIndexes:removedIndexes: was not returning values for addedIndexes that could be used with insertRowsAtIndexPaths:withRowAnimation:. This resulted in some of the funkiness that could be easily seen when trying out the demo in SKViewController. I think that actually explains the problems with it, not any UITableView bugs. I wrote a patch that seems to fix the problems and changed your UITableView tests so that it actually checks the results.
- Changed indexesOfCommonElementsWithArray to return addedIndexes in the format insertRowsAtIndexPaths:withRowAnimation: expects. It expects the provided index paths to be valid when considered from the point of view of the final table data, not from the point of view of the initial table data. i.e., at the end of the updates, tableView:cellForRowAtIndexPath: for each of the provided index paths must return the rows that were inserted.
- Added tests to verify adding, removing and reordering elements behaves as expected on an actual UITableView.
