### PR TITLE
Dynamically allocate a two-dimensional lengths array

### DIFF
--- a/LongestCommonSubsequence/NSArray+LongestCommonSubsequence.m
+++ b/LongestCommonSubsequence/NSArray+LongestCommonSubsequence.m
@@ -20,10 +20,18 @@
 
     NSInteger **lengths = calloc(firstDimension, sizeof(NSInteger*));
 
+    if(lengths == NULL) {
+        [[self class] raiseMallocExceptionWithBytes: firstDimension * sizeof(NSInteger*) * CHAR_BIT / 8];
+    }
+
     const NSInteger secondDimension = array.count + 1;
 
     for(NSInteger i = 0; i < firstDimension; i++) {
       lengths[i] = calloc(secondDimension, sizeof(NSInteger));
+
+      if(lengths[i] == NULL) {
+          [[self class] raiseMallocExceptionWithBytes: secondDimension * sizeof(NSInteger) * CHAR_BIT / 8];
+      }
     }
 
     for (NSInteger i = self.count; i >= 0; i--) {
@@ -88,6 +96,14 @@
     }
     return commonIndexes;
     
+}
+
++ (void) raiseMallocExceptionWithBytes: (long long) bytes {
+    NSString* const bytesString = [NSByteCountFormatter stringFromByteCount: bytes countStyle: NSByteCountFormatterCountStyleMemory];
+
+    NSString* const format = [NSString stringWithFormat: @"Unable to allocate %@.", bytesString];
+
+    [NSException raise: NSMallocException format: @"%@", format];
 }
 
 @end

--- a/LongestCommonSubsequence/NSArray+LongestCommonSubsequence.m
+++ b/LongestCommonSubsequence/NSArray+LongestCommonSubsequence.m
@@ -15,9 +15,17 @@
 }
 
 - (NSIndexSet*) indexesOfCommonElementsWithArray:(NSArray*)array addedIndexes:(NSIndexSet**)addedIndexes removedIndexes:(NSIndexSet**)removedIndexes {
-    
-    NSInteger lengths[self.count+1][array.count+1];
-    
+
+    const NSInteger firstDimension = self.count + 1;
+
+    NSInteger **lengths = calloc(firstDimension, sizeof(NSInteger*));
+
+    const NSInteger secondDimension = array.count + 1;
+
+    for(NSInteger i = 0; i < firstDimension; i++) {
+      lengths[i] = calloc(secondDimension, sizeof(NSInteger));
+    }
+
     for (NSInteger i = self.count; i >= 0; i--) {
         for (NSInteger j = array.count; j >= 0; j--) {
             
@@ -43,7 +51,13 @@
             j++;
         }
     }
-    
+
+    for(NSInteger i = 0; i < firstDimension; i++) {
+      free(lengths[i]);
+    }
+
+    free(lengths);
+
     if (removedIndexes) {
         NSMutableIndexSet *_removedIndexes = [NSMutableIndexSet indexSet];
         


### PR DESCRIPTION
Sometimes, when LCS is calculated for two relatively large arrays (more than 1000 elements in each) the program crashes with a `SIGSEGV`. It seems like stack-based arrays can't handle the scale. This pull request fixes the issue by dynamic allocation of a two-dimensional `lengths` array.

I can't figure out what is the best way to handle a `calloc` failure. What should we do if `lengths` allocation fails — return a meaningless result or just crash?
